### PR TITLE
Add websocket to get coinmarketcap, total volume

### DIFF
--- a/backend/routes/prices.go
+++ b/backend/routes/prices.go
@@ -22,3 +22,7 @@ func getWebsocketFundingRate(context *gin.Context) {
 func getWebsocketKline(context *gin.Context) {
 	websocket.KlineSocket(context)
 }
+
+func getWebsocketMarketCap(context *gin.Context) {
+	websocket.MarketCapSocket(context)
+}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -10,4 +10,5 @@ func RegisterRoutes(server *gin.Engine) {
 	authenticated.GET("/v1/vip1/kline", getKline)
 	authenticated.GET("/v1/funding-rate/websocket", getWebsocketFundingRate)
 	authenticated.GET("/v1/vip1/kline/websocket", getWebsocketKline)
+	authenticated.GET("/v1/market-stats", getWebsocketMarketCap)
 }

--- a/backend/services/price-service/models/market_cap.go
+++ b/backend/services/price-service/models/market_cap.go
@@ -1,0 +1,27 @@
+package models
+
+type MarketCapResponse struct {
+	Symbol     string `json:"symbol"`
+	MarketData struct {
+		MarketCap struct {
+			USD int64 `json:"usd"`
+		} `json:"market_cap"`
+		TotalVolume struct {
+			USD int64 `json:"usd"`
+		} `json:"total_volume"`
+	} `json:"market_data"`
+}
+
+type FormatMarketCapResponse struct {
+	Symbol      string `json:"symbol"`
+	MarketCap   int64  `json:"market_cap"`
+	TotalVolume int64  `json:"24h_volume"`
+}
+
+func CreateReponseFormat(symbol string, marketCap, totalVolume int64) *FormatMarketCapResponse {
+	return &FormatMarketCapResponse{
+		Symbol:      symbol,
+		MarketCap:   marketCap,
+		TotalVolume: totalVolume,
+	}
+}

--- a/backend/services/price-service/services/websocket/get_market_cap.go
+++ b/backend/services/price-service/services/websocket/get_market_cap.go
@@ -1,0 +1,133 @@
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/dath-241/coin-price-be-go/services/price-service/models"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+func MarketCapSocket(context *gin.Context) {
+	// Create websocket
+	ws, err := Upgrade(context.Writer, context.Request)
+	if err != nil {
+		log.Println("Upgrade error: ", err)
+		return
+	}
+	defer ws.Close()
+
+	symbol := context.Query("symbol")
+	urlMarketCap := fmt.Sprintf("https://api.coingecko.com/api/v3/coins/%s", symbol)
+
+	// done chan to check if the main go routine is continue or not
+	done := make(chan struct{})
+	// exit chan to check if the go func is continue or not (check for stop loop)
+	exit := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		isContinue := processMarketCapSocket(urlMarketCap, ws)
+		if !isContinue {
+			return
+		}
+		for {
+			select {
+			case <-exit:
+				return
+			case <-ticker.C:
+				isContinue := processMarketCapSocket(urlMarketCap, ws)
+				if isContinue {
+					continue
+				} else {
+					return
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	for {
+		_, msg, err := ws.ReadMessage()
+		if err != nil {
+			close(exit)
+			break
+		}
+		if string(msg) == "disconnect" {
+			close(exit)
+			break
+		}
+	}
+
+	<-done
+}
+
+func processMarketCapSocket(urlMarketCap string, ws *websocket.Conn) bool {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", urlMarketCap, nil)
+	if err != nil {
+		log.Println("ERROR Request")
+		return true
+	}
+
+	q := url.Values{}
+	q.Add("localization", "false")
+	q.Add("tickers", "false")
+	q.Add("community_data", "false")
+	req.URL.RawQuery = q.Encode()
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println("Error http request")
+		return true
+	}
+
+	// Get status code
+	statusCode := resp.StatusCode
+	if statusCode == http.StatusTooManyRequests {
+		ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "Rate limit, please wait."))
+		return false
+
+	} else if statusCode != http.StatusOK {
+		ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "Symbol missing or invalid"))
+		return false
+	}
+
+	// get data response
+	var marketCapResponse models.MarketCapResponse
+	err = json.NewDecoder(resp.Body).Decode(&marketCapResponse)
+	resp.Body.Close()
+	if err != nil {
+		log.Println("Error from getting response, error: ", err)
+		return true
+	}
+
+	// format response
+	dataResponse := models.CreateReponseFormat(
+		marketCapResponse.Symbol,
+		marketCapResponse.MarketData.MarketCap.USD,
+		marketCapResponse.MarketData.TotalVolume.USD,
+	)
+
+	responseJSON, err := json.Marshal(&dataResponse)
+	if err != nil {
+		errorMsg := fmt.Sprintf("JSON marshal error: %s", err.Error())
+		log.Println(errorMsg)
+		return true
+	}
+
+	// return message response to client
+	if err = ws.WriteMessage(websocket.TextMessage, []byte(responseJSON)); err != nil {
+		errorMsg := fmt.Sprintf("Write error to client %s", err.Error())
+		log.Println(errorMsg)
+		return false
+	}
+	return true
+}

--- a/backend/services/price-service/services/websocket/get_market_cap.go
+++ b/backend/services/price-service/services/websocket/get_market_cap.go
@@ -33,7 +33,7 @@ func MarketCapSocket(context *gin.Context) {
 
 	go func() {
 		defer close(done)
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(15 * time.Minute)
 		defer ticker.Stop()
 		isContinue := processMarketCapSocket(urlMarketCap, ws)
 		if !isContinue {

--- a/backend/services/price-service/services/websocket/get_market_cap.go
+++ b/backend/services/price-service/services/websocket/get_market_cap.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/dath-241/coin-price-be-go/services/price-service/models"
@@ -22,7 +23,7 @@ func MarketCapSocket(context *gin.Context) {
 	}
 	defer ws.Close()
 
-	symbol := context.Query("symbol")
+	symbol := strings.ToLower(context.Query("symbol"))
 	urlMarketCap := fmt.Sprintf("https://api.coingecko.com/api/v3/coins/%s", symbol)
 
 	// done chan to check if the main go routine is continue or not


### PR DESCRIPTION
**2.3 Add funding rate websocket**

- **Method**: SUBSCRIBE

- **Endpoint:** /api/v1/market-stats

- **Description:** lấy funding rate realtime

- **Query Parameters**:

  - `symbol`: ký hiệu của đồng coin (VD: bitcoin)

- **Message:** 
```json
{
    "symbol": "btc",
    "market_cap": 1482929781719,
    "24h_volume": 80898593637
}
```
Success:
![image](https://github.com/user-attachments/assets/59b5604b-beb6-4ab7-a014-e6dae9fb8b1d)
<br>
Failed: close socket
![image](https://github.com/user-attachments/assets/3e5667c6-a017-4d4a-abe8-5fe001817669)
<br>
Limit rate: close socket
![image](https://github.com/user-attachments/assets/0ff7728c-8080-441e-a36b-3da63d611e2c)



